### PR TITLE
doc: add hint that complete git repo is needed for docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ Look for missing tracks in your lidarr library and download them from youtube.
 # Docker Usage
 
 ### docker run
+The docker build need the `.git` directory, so be sure to clone the repository.
+Using a shallow zip file from this repo does not work.
+
 ```
+git clone https://github.com/dmzoneill/lidarr-youtube-downloader.git
 docker build -t lyd .
 # you need to be careful that the path matches the path that lidarr knows
 docker run \


### PR DESCRIPTION
The docker build only works if you clone the gut repository. If you use a flat copy, then the build fails.

This PR adds this hint to the readme 