### PR TITLE
build: remove numpy dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt install -y ffmpeg python3 curl python3-pi
 RUN python3 -m pip install --no-deps -U yt-dlp
 RUN mv /usr/local/bin/yt-dlp /usr/bin/youtube-dl
 RUN chmod +x /usr/bin/youtube-dl
-RUN pip3 install requests eyed3 youtube-search-python numpy typer
+RUN pip3 install requests eyed3 youtube-search-python typer
 COPY lidarr_youtube_downloader/lyd.py /
 COPY lidarr_youtube_downloader/view/ /view
 CMD ["python3", "-u", "/lyd.py"]


### PR DESCRIPTION
Numpy is a big package and needs a lot of time for installing. As numpy is not used in the whole codebase, this removes it from the dependency list